### PR TITLE
Update versi laravel terbaru

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "illuminate/support": "5.7.*|5.8.*|6.*"
+        "php": "^7|^8",
+        "illuminate/support": "5.7.*|5.8.*|6.*|7.*|8.*"
     },
     "require-dev": {
         "orchestra/testbench": "3.8.*",


### PR DESCRIPTION
Saat ini hanya support maksimal `6.x`, saya tambahkan untuk `7.x` dan `8.x`. Sekalian versi phpnya dari `7.1` ke  `7.x` dan `8.x`.

Error saat instalasi di `laravel:^7.x`

![image](https://user-images.githubusercontent.com/20186786/109806309-2504c280-7c57-11eb-9490-1377234d4706.png)

Error saat instalasi di `laravel:^8.x`

![image](https://user-images.githubusercontent.com/20186786/109806412-41a0fa80-7c57-11eb-814d-4962d8456f17.png)
